### PR TITLE
Set unique label for core app

### DIFF
--- a/cravensworth/core/apps.py
+++ b/cravensworth/core/apps.py
@@ -5,3 +5,4 @@ class CravensworthCoreConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'cravensworth.core'
     verbose_name = 'Django Cravensworth'
+    label = 'cravensworth_core'


### PR DESCRIPTION
Sets core app label to "cravensworth_core".